### PR TITLE
fix bug for generating schema when there was no header field line in csv file

### DIFF
--- a/ml-tools-python/awspyml.py
+++ b/ml-tools-python/awspyml.py
@@ -287,8 +287,8 @@ class SchemaGuesser(object):
             if header_line:
                 self.schema.set_variable_name(idx, name)
             else:
-                self.schema.set_variable_name(
-                    "Var%0" + digits + "d" % (idx + 1))
+                name = "Var{number:0{width}d}".format(width=digits, number = idx + 1)
+                self.schema.set_variable_name(idx, name)
 
     def _guess_if_header_line_present(self):
         header_row = self.data[0]


### PR DESCRIPTION
## bug summary

There were two bugs in the code(`ml-tools-python`).

1st one was string formatting (`"Var%0" + digits + "d" % (idx + 1)`)
2nd one was not passing enough arguments for `Schema::set_variable_name` method

This PR fixes both of them.
## how to reproduce

```
$ cat no_header.csv
1,3,basic.4y,no,no,1,261,0
2,1,high.school,no,no,22,149,0
3,1,high.school,yes,no,65,226,1
$ python guess_schema.py no_header.csv
Traceback (most recent call last):
  File "guess_schema.py", line 39, in <module>
    schema = awspyml.SchemaGuesser().from_file(data_fn, target_variable=target)
  File "/Users/george/dev/machine-learning-samples/ml-tools-python/awspyml.py", line 243, in from_file
    schema = self._guess_schema_from_data(header_line)
  File "/Users/george/dev/machine-learning-samples/ml-tools-python/awspyml.py", line 253, in _guess_schema_from_data
    self._name_attributes(header_line)
  File "/Users/george/dev/machine-learning-samples/ml-tools-python/awspyml.py", line 291, in _name_attributes
    "Var%0" + digits + "d" % (idx + 1))
TypeError: cannot concatenate 'str' and 'int' objects
```
