### PR TITLE
Changed BFTask to AWSTask as the new version of AWSSDK renamed classes from Bolts

### DIFF
--- a/mobile-ios/ViewController.m
+++ b/mobile-ios/ViewController.m
@@ -44,7 +44,7 @@ AWSMachineLearning *machineLearning;
     getMLModelInput.MLModelId = MLModelId;
     
     // Call Get ML Model
-    [[[machineLearning getMLModel:getMLModelInput] continueWithSuccessBlock:^id(BFTask *task) {
+    [[[machineLearning getMLModel:getMLModelInput] continueWithSuccessBlock:^id(AWSTask *task) {
         AWSMachineLearningGetMLModelOutput *getMLModelOutput = task.result;
         
         if (getMLModelOutput.status != AWSMachineLearningEntityStatusCompleted) {
@@ -60,7 +60,7 @@ AWSMachineLearning *machineLearning;
         // Since model is complete and real-time endpoint is ready, call predict
         return [self predict:MLModelId withRecord: @{}];
 
-    }] continueWithBlock:^id(BFTask *task) {
+    }] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
             NSLog(@"Error %@", task.error);
         }
@@ -75,7 +75,7 @@ AWSMachineLearning *machineLearning;
     }];
 }
 
-- (BFTask *) predict:(NSString *)mlModelId withRecord:(NSDictionary *)record {
+- (AWSTask *) predict:(NSString *)mlModelId withRecord:(NSDictionary *)record {
     AWSMachineLearningPredictInput *predictInput = [AWSMachineLearningPredictInput new];
     predictInput.predictEndpoint = endpoint;
     predictInput.MLModelId = mlModelId;


### PR DESCRIPTION
The AWS Mobile SDK for iOS 2.2.0 no longer includes third-party frameworks. These classes must be updated:
`BFTask` -> `AWSTask`
`BFExecutor` -> `AWSExecutor`

Documents can be found at: 
http://docs.aws.amazon.com/mobile/sdkforios/developerguide/awstask.html
